### PR TITLE
Check pyver variable

### DIFF
--- a/python_runner/runner.py
+++ b/python_runner/runner.py
@@ -78,7 +78,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
     env["CONAN_LOGGING_LEVEL"] = "50" if platform.system() == "Darwin" else "50"
     env["CHANGE_AUTHOR_DISPLAY_NAME"] = ""
     env["TESTING_REVISIONS_ENABLED"] = "True" if flavor == "enabled_revisions" else "False"
-    if sys.version_info.major == 2:
+    if pyver.startswith("py2"):
         env["USE_UNSUPPORTED_CONAN_WITH_PYTHON_2"] = "True"
     # Related with the error: LINK : fatal error LNK1318: Unexpected PDB error; RPC (23) '(0x000006BA)'
     # More info: http://blog.peter-b.co.uk/2017/02/stop-mspdbsrv-from-breaking-ci-build.html


### PR DESCRIPTION
In this function it is running `python` (which is the one in the system), we need to check `pyver` because it is the actual version for the tests.