### PR TITLE
[WIP] CI workflows

### DIFF
--- a/release.dot
+++ b/release.dot
@@ -1,0 +1,48 @@
+# Once we have a commit we want to tag
+
+digraph G {
+    rankdir=LR;
+
+    subgraph cluster_major {
+        label = "Major release 1.x.0";
+
+        Start_major [shape=diamond, label="Start"];
+        End_major [shape=diamond, label="End"];
+
+        validate [label="Basic checks:\n· validate version\n· check green CI"];
+        validate_branch [label="Topology checks:\n· is master branch"];
+        validate_milestone [label="Check milestone:\n· assigned PRs\n· changelogs\n· docs"];
+        create_tag [label="create\nbranch and tag"];
+
+        input_artifacts [style=invisible,fixedsize=true,width=0,height=0];
+        output_artifacts [style=invisible,fixedsize=true,width=0,height=0];
+        subgraph cluster_artifacts {
+            label = "Generate artifacts";
+            deb -> test_deb;
+            win_pyinstaller -> test_win_pyinstaller;
+            pypi -> test_pypi;
+        }
+
+        Start_major -> validate;
+        validate -> validate_branch -> validate_milestone;
+        validate_milestone -> input_artifacts [arrowhead=none];
+        input_artifacts -> deb;
+        input_artifacts -> win_pyinstaller;
+        input_artifacts -> pypi;
+        test_deb -> output_artifacts [arrowhead=none];
+        test_win_pyinstaller -> output_artifacts [arrowhead=none];
+        test_pypi -> output_artifacts [arrowhead=none];
+        output_artifacts -> create_tag;
+        create_tag -> deploy;
+        deploy -> End_major;
+    }
+
+    subgraph cluster_minor {
+        label = "Minor release: 1.21.x";
+        Start_minor [shape=diamond, label="Start"];
+        End_minor [shape=diamond, label="End"];
+
+        Start_minor-> A -> B -> End_minor;
+    }
+    
+}

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -16,6 +16,10 @@ class TestRunner {
 
 
     void run(){
+        script.stage("This is staging") {
+            script.echo "Yes, it is"
+        }
+
         cancelPreviousCommits()
         testLevelConfig.init() // This will read the tags from the PR if this is a PR
         runRESTTests()

--- a/workflow.dot
+++ b/workflow.dot
@@ -1,0 +1,153 @@
+digraph G {
+    rankdir=LR;
+    graph [fontsize=10 fontname="Verdana"];
+    node [shape=record fontsize=10 fontname="Verdana"];
+
+    Start [shape = diamond];
+    End [shape = diamond];
+
+    subgraph cluster_nightly {
+        label = "Nightly/Preflight";
+
+        subgraph cluster_regular {
+            label = "Regular testing";
+
+            # First stage to test everything related to Python
+            in_stage_0 [style=invisible,fixedsize=true,width=0,height=0];
+            out_stage_0 [style=invisible,fixedsize=true,width=0,height=0];
+
+            subgraph cluster_stage_0 {
+                label = "Unittests\n(raw python)";
+                rank = same;
+                py36;
+                py37;
+                py38;
+                py_any [label="..."];
+            }
+
+            Start -> in_stage_0 [arrowhead=none];
+            in_stage_0 -> py36 -> out_stage_0 [arrowhead=none];
+            in_stage_0 -> py37 -> out_stage_0 [arrowhead=none];
+            in_stage_0 -> py38 -> out_stage_0 [arrowhead=none];
+            in_stage_0 -> py_any -> out_stage_0 [arrowhead=none];
+
+            # Second stage to test some functional integrations, system tools are needed, but only
+            #   one version is provided
+            in_stage_1 [style=invisible,fixedsize=true,width=0,height=0];
+            out_stage_1 [style=invisible,fixedsize=true,width=0,height=0];
+
+            subgraph cluster_stage_1 {
+                label = "Functional\nCMake + compiler";
+                rank = same;
+                py3_win;
+                py3_mac;
+                py3_linux;
+            } 
+
+            out_stage_0 -> in_stage_1 [arrowhead=none];
+            in_stage_1 -> py3_win -> out_stage_1 [arrowhead=none];
+            in_stage_1 -> py3_mac -> out_stage_1 [arrowhead=none];
+            in_stage_1 -> py3_linux -> out_stage_1 [arrowhead=none];
+
+            # Third stage: several versions of system tools available. These tests should ensure
+            #   they are using the one expected
+            in_stage_2 [style=invisible,fixedsize=true,width=0,height=0];
+            out_stage_2 [style=invisible,fixedsize=true,width=0,height=0];
+
+            subgraph cluster_stage_2 {
+                label = "Integration\nSeveral versions available\nChange defaults";
+                rank = same;
+                win_vs_2019;
+                win_vs_2017;
+                win_cmake_x;
+
+                mac_cmake_x;
+
+                linux_gcc;
+                linux_clang;
+                linux_cmake;
+                linux_xbuild;
+            }
+
+            out_stage_1 -> in_stage_2 [arrowhead=none];
+            in_stage_2 -> win_vs_2019 -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> win_vs_2017 -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> win_cmake_x -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> mac_cmake_x -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> linux_gcc -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> linux_clang -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> linux_cmake -> out_stage_2 [arrowhead=none];
+            in_stage_2 -> linux_xbuild -> out_stage_2 [arrowhead=none];
+        }
+
+        # Next step: Check we haven't break recipes from Conan Center
+        in_stage_3 [style=invisible,fixedsize=true,width=0,height=0];
+        out_stage_3 [style=invisible,fixedsize=true,width=0,height=0];
+
+        subgraph cluster_stage_3 {
+            label = "Tests recipes conan-center";
+            rank = same;
+            poco_1_10 [label="poco/1.10"];
+            zlib_1_2_11 [label="zlib/1.2.11"];
+            recipe_x [label="..."];
+        }
+        
+        out_stage_2 -> in_stage_3 [arrowhead=none];
+        in_stage_3 -> poco_1_10 -> out_stage_3 [arrowhead=none];
+        in_stage_3 -> zlib_1_2_11 -> out_stage_3 [arrowhead=none];
+        in_stage_3 -> recipe_x -> out_stage_3 [arrowhead=none];
+
+        # Next step: Hooks
+        in_stage_hooks [style=invisible,fixedsize=true,width=0,height=0];
+        out_stage_hooks [style=invisible,fixedsize=true,width=0,height=0];
+
+        subgraph cluster_stage_hooks {
+            label = "Hooks";
+            rank = same;
+            win_hooks;
+            mac_hooks;
+            linux_hooks;
+        }
+        
+        out_stage_3 -> in_stage_hooks [arrowhead=none];
+        in_stage_hooks -> win_hooks -> out_stage_hooks [arrowhead=none];
+        in_stage_hooks -> mac_hooks -> out_stage_hooks [arrowhead=none];
+        in_stage_hooks -> linux_hooks -> out_stage_hooks [arrowhead=none];
+
+        # Next step: Other tool we don't want to break
+        in_stage_4 [style=invisible,fixedsize=true,width=0,height=0];
+        out_stage_4 [style=invisible,fixedsize=true,width=0,height=0];
+
+        subgraph cluster_stage_4 {
+            label = "Artifactory";
+            rank = same;
+            artifactory_latest;
+            artifactory_x;
+            artifactory_y;
+        }
+        
+        out_stage_hooks -> in_stage_4 [arrowhead=none];
+        in_stage_4 -> artifactory_latest -> out_stage_4 [arrowhead=none];
+        in_stage_4 -> artifactory_x -> out_stage_4 [arrowhead=none];
+        in_stage_4 -> artifactory_y -> out_stage_4 [arrowhead=none];
+
+        # Next step: Plugins
+        in_stage_5 [style=invisible,fixedsize=true,width=0,height=0];
+        out_stage_5 [style=invisible,fixedsize=true,width=0,height=0];
+
+        subgraph cluster_stage_5 {
+            label = "Plugins";
+            rank = same;
+            plugin_vs;
+            plugin_jenkins;
+            plugin_clion;
+        }
+        
+        out_stage_4 -> in_stage_5 [arrowhead=none];
+        in_stage_5 -> plugin_vs -> out_stage_5 [arrowhead=none];
+        in_stage_5 -> plugin_jenkins -> out_stage_5 [arrowhead=none];
+        in_stage_5 -> plugin_clion -> out_stage_5 [arrowhead=none];
+
+        out_stage_5 -> End;
+    }
+}


### PR DESCRIPTION
This PR proposes a full workflow (graphs, not source) for the test suite and the release process (major and minor ones). After it, let's see if the implementation is feasible

Pending:

- [ ] enable/disable revisions, how to handle them, is it needed to run twice all the jobs?
- [ ] attributes: list them, which ones are useful?


## Test suite

![image](https://user-images.githubusercontent.com/1406456/73764476-62a4cc80-4773-11ea-909a-93663d7c5371.png)

There are several stages (from the point of view of the CI):


### Regular test suite: pull-request and merges

 * **Unittests**: no tools from the system, everything should be pure-python or mocked so, in theory, all of this can run just in Linux/Docker containers
    + Check all the different python versions we want to use: 2.7 (if not deprecated), 3.5 (default for Ubuntu/Debian), 3.7 (old-new version), 3.8 (latest one)
    + Run also `CONAN_V2_MODE"
 * **Functional**: they can use tools from the system, the node will provide only one alternative of underlying tools like GCC, CMake, Visual Studio,...
    + Only one python version
    + Only one job per platform
 * **Integration**: in this stage several versions of the same tool are available in the system
   + Several CMake versions
   + GCC and Clang
   + VS with different toolchains (no idea how to provide this in the CI with only one Windows machine)
   + We can add here other architectures using Docker

Here we should be able to take into account attributes like `slow` or to increase/decrease the number of python versions.


### Nightly/Preflight

 * Test recipes from **Conan-Center**: check several recipes to ensure we are not breaking anything
 * **Hooks**/**Examples**: these repos are running every night using `develop` branch, but we don't want to release and break them. Shall we run them again?
 * **Artifactory**: run testing related to a bunch of Artifactory versions
 * **Plugins**: run tests for the plugin, can we run them?

For all of these jobs we should add a **retry policy**: better to retry a true negative than to launch all the pipeline from the beginning. See if we can `try/catch` in the Jenkins job and, depending on the error message, fire the retry or not.




## Releases 


![image](https://user-images.githubusercontent.com/1406456/73764464-56b90a80-4773-11ea-8d78-fe08882a7d16.png)
