### PR TITLE
Populate 'TESTING_REVISIONS_ENABLED' only if given

### DIFF
--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -56,7 +56,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
         traverse_namespace = "--traverse-namespace"
 
     #  --nocapture
-    command = "set && virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
+    command = "virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
               "{source_cmd} \"{venv_exe}\" && " \
               "{pip_installs} " \
               "python setup.py install && " \
@@ -97,8 +97,6 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
 
     with chdir(source_folder):
         with environment_append(env):
-            from pprint import pprint
-            pprint(env)
             run(command)
 
 

--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -83,7 +83,8 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
     env["PYTHONPATH"] = source_folder
     env["CONAN_LOGGING_LEVEL"] = "50" if platform.system() == "Darwin" else "50"
     env["CHANGE_AUTHOR_DISPLAY_NAME"] = ""
-    env["TESTING_REVISIONS_ENABLED"] = "True" if flavor == "enabled_revisions" else "False"
+    if flavor == "enabled_revisions":
+        env["TESTING_REVISIONS_ENABLED"] = "True"
     if pyver.startswith("py2"):
         env["USE_UNSUPPORTED_CONAN_WITH_PYTHON_2"] = "True"
     # Related with the error: LINK : fatal error LNK1318: Unexpected PDB error; RPC (23) '(0x000006BA)'
@@ -125,7 +126,7 @@ if __name__ == "__main__":
     parser.add_argument('--num_cores', type=int, help='Number of cores to use', default=3)
     parser.add_argument('--exclude_tags', '-e', nargs=1, action=Extender,
                         help='Tags to exclude from testing, e.g.: rest_api')
-    parser.add_argument('--flavor', '-f', help='enabled_revisions, disabled_revisions')
+    parser.add_argument('--flavor', '-f', help='enabled_revisions (or nothing)')
     args = parser.parse_args()
 
     if args.include_tags and args.exclude_tags:

--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -56,7 +56,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
         traverse_namespace = "--traverse-namespace"
 
     #  --nocapture
-    command = "virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
+    command = "set && virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
               "{source_cmd} \"{venv_exe}\" && " \
               "{pip_installs} " \
               "python setup.py install && " \
@@ -97,6 +97,8 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
 
     with chdir(source_folder):
         with environment_append(env):
+            from pprint import pprint
+            pprint(env)
             run(command)
 
 

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -45,6 +45,10 @@ class TestRunner {
         return revisionsEnabled ? "enabled_revisions" : "disabled_revisions"
     }
 
+    private static String getFlavorCommandLine(boolean revisionsEnabled){
+        return revisionsEnabled ? " --flavor enabled_revisions" : ""
+    }
+
     void runRESTTests(){
         List<String> excludedTags = []
         List<String> includedTags = ["rest_api", "local_bottle"]
@@ -136,6 +140,7 @@ class TestRunner {
             eTags += " -i " + includedTags.join(' -i ')
         }
         String flavor = getFlavor(revisionsEnabled)
+        String flavor_cmd = getFlavorCommandLine(revisionsEnabled)
 
         def ret = {
             script.node(slaveLabel) {

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,7 @@ class TestRunner {
                         try {
 
                             script.withEnv(["CONAN_TEST_FOLDER=${workdir}"]) {
-                                script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} --flavor ${flavor} ${eTags}")
+                                script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }
                         }
                         finally {
@@ -200,7 +200,7 @@ class TestRunner {
                     } else if (slaveLabel == "Macos") {
                         try {
                             script.withEnv(['PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin']) {
-                                script.sh(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} ${workdir} ${numcores} --flavor ${flavor} ${eTags}")
+                                script.sh(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} ${workdir} ${numcores} ${flavor_cmd} ${eTags}")
                             }
                         }
                         finally {
@@ -212,7 +212,7 @@ class TestRunner {
                         try {
                             script.sh("docker pull conanio/conantests")
                             script.docker.image('conanio/conantests').inside("-e CONAN_USER_HOME=${sourcedir} -v${sourcedir}:${sourcedir}") {
-                                script.sh(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} /tmp ${numcores} --flavor ${flavor} ${eTags}")
+                                script.sh(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} /tmp ${numcores} ${flavor_cmd} ${eTags}")
                             }
                         }
                         finally {

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -6,11 +6,13 @@ class TestRunner {
     private static final String restTmpBase = "/tmp/"
     private static final String numCores = "3"
     private script;
+    private final String branch;
     private TestLevelConfig testLevelConfig
 
-    TestRunner(script){
+    TestRunner(script, branch){
         testLevelConfig = new TestLevelConfig(script)
         this.script = script
+        this.branch = branch
     }
 
 

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -6,13 +6,11 @@ class TestRunner {
     private static final String restTmpBase = "/tmp/"
     private static final String numCores = "3"
     private script;
-    private final String branch;
     private TestLevelConfig testLevelConfig
 
-    TestRunner(script, branch){
+    TestRunner(script){
         testLevelConfig = new TestLevelConfig(script)
         this.script = script
-        this.branch = branch
     }
 
 

--- a/vars/conanCI.groovy
+++ b/vars/conanCI.groovy
@@ -13,11 +13,11 @@ if(causeClass == "jenkins.branch.BranchIndexingCause"){
 }
 
 
-def runBuild(script) {
+def runBuild(script, branch) {
     script.get_jenkins_instance = {
         return Jenkins.instance
     }
 
-    new TestRunner(script).run()
+    new TestRunner(script, branch).run()
 }
 

--- a/vars/conanCI.groovy
+++ b/vars/conanCI.groovy
@@ -13,11 +13,11 @@ if(causeClass == "jenkins.branch.BranchIndexingCause"){
 }
 
 
-def runBuild(script, branch) {
+def runBuild(script) {
     script.get_jenkins_instance = {
         return Jenkins.instance
     }
 
-    new TestRunner(script, branch).run()
+    new TestRunner(script).run()
 }
 


### PR DESCRIPTION
This PR modifies how we populate 'TESTING_REVISIONS_ENABLED'. This environment variable will only be populated if it is explicitly set:
 * by default, no value is set
 * if `revisions_enabled` it will get value `True`

Note.- From the CI, there is no way to get `revisions_enabled=False` or something like `revisions_disabled`

This is needed for the transition to Conan v2. Those tests will be initialized (if nothing is set) with revisions enabled, we cannot pass by default from the CI the value `TESTING_REVISIONS_ENABLED=False` which will disable the revisions.

_Only to be merged, if the PR to Conan with [tests related to Conan v2](https://github.com/conan-io/conan/pull/6490) is going to be merged_

On top of #14