### PR TITLE
New docker images to use in our test-suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE gcc 12 clang 12 -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker exec conanio/$IMAGE -v docker_images/_tests:/home/tests /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
+  - docker exec travis-ci-$IMAGE -v docker_images/_tests:/home/tests /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,21 @@ jobs:
       after_success:
 
     # Generate docker images (only if modified)
+<<<<<<< HEAD
     - stage: docker
       name: conanio/conantests
       env: 
         - IMAGE=conantests
         - LINTER=false
     - name: conanio/ci-unittests
+=======
+    #- stage: docker conanio/conantests
+    #  env: 
+    #    - IMAGE=conan_tests
+    #    - LINTER=false
+    - stage: docker
+      name: conanio/ci-unittests
+>>>>>>> let's run tests inside docker images
       env: 
         - IMAGE=ci-unittests
     - name: conanio/ci-functional
@@ -59,6 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
+  - docker exec conanio/$IMAGE -v docker_images/_tests:/home/tests /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - name: conanio/ci-functional
       env: 
        - IMAGE=ci-functional
-       - IMAGE_ARGS=gcc 12 clang 12 cmake 12
+       - IMAGE_ARGS="gcc 12 clang 12 cmake 12"
     
       
 language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -t -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "source /root/environment.sh && export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
   # Run tests outside the docker image
-  - . $(pwd)/docker_images/_tests/run_outside_tests.sh
+  - . $(pwd)/docker_images/_tests/run_outside_tests.sh $(pwd)/docker_images/_tests/test_$IMAGE/
   # Run some tests inside the image
   - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,14 @@ jobs:
       env: 
         - IMAGE=conantests
         - LINTER=false
-
+    - name: conanio/ci-unittests
+      env: 
+        - IMAGE=ci-unittests
+    - name: conanio/ci-functional
+      env: 
+       - IMAGE=ci-functional
+    
+      
 language: minimal
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ script:
 
 after_success:
   - |
-    if [[ "$TRAVIS_BRANCH" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]
+    if [[ "$TRAVIS_BRANCH" =~ "^(staging|master)$" && "${TRAVIS_PULL_REQUEST}" == "false" ]]
     then
-      echo $DOCKER_PASSWORD | docker login --username $DOCKER_USERNAME --password-stdin;
+      echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin;
       docker push conanio/$IMAGE;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ jobs:
       after_success:
 
     # Generate docker images (only if modified)
-    #- stage: docker conanio/conantests
+    #- stage: docker $DOCKER_USERNAME/conantests
     #  env: 
     #    - IMAGE=conan_tests
     #    - LINTER=false
     - stage: docker
-      name: conanio/ci-unittests
+      name: $DOCKER_USERNAME/ci-unittests
       env: 
         - IMAGE=ci-unittests
-    - name: conanio/ci-functional
+    - name: $DOCKER_USERNAME/ci-functional
       env: 
        - IMAGE=ci-functional
        - IMAGE_ARGS="gcc 12 clang 12 cmake 12"  # Non valid values
@@ -51,7 +51,7 @@ before_install:
       travis_terminate 0
     fi
 script:
-  - echo "Building docker image 'conanio/$IMAGE'"
+  - echo "Building docker image '$DOCKER_USERNAME/$IMAGE'"
   - |
     if [[ "$LINTER" != "false" ]]
     then
@@ -59,16 +59,16 @@ script:
     fi
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
-  - docker tag travis-ci-$IMAGE conanio/$IMAGE
+  - docker tag travis-ci-$IMAGE $DOCKER_USERNAME/$IMAGE
   # Run tests outside the docker image
   - . $(pwd)/docker_images/_tests/run_outside_tests.sh $(pwd)/docker_images/_tests/test_$IMAGE/
   # Run some tests inside the image
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE $DOCKER_USERNAME/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |
     if [[ "$TRAVIS_BRANCH" =~ "^(staging|master)$" && "${TRAVIS_PULL_REQUEST}" == "false" ]]
     then
       echo $DOCKER_TOKEN | docker login --username $DOCKER_USERNAME --password-stdin;
-      docker push conanio/$IMAGE;
+      docker push $DOCKER_USERNAME/$IMAGE;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   - |
     if [[ "$LINTER" != "false" ]]
     then
-      docker run --rm -i hadolint/hadolint < docker_images/$IMAGE/Dockerfile; 
+      docker run --rm -i hadolint/hadolint < docker_images/$IMAGE/Dockerfile || true;
     fi
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -t -v "$(pwd)/docker_images/_tests:/home/tests" conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
+  - docker run -t -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
     - name: conanio/ci-functional
       env: 
        - IMAGE=ci-functional
-       - IMAGE_ARGS="gcc 12 clang 12 cmake 12"
+       - IMAGE_ARGS="gcc 12 clang 12 cmake 12"  # Non valid values
     
       
 language: minimal
@@ -60,6 +60,9 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
+  # Run tests outside the docker image
+  - . /home/tests/run_outside_tests.sh
+  # Run some tests inside the image
   - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
        - IMAGE_ARGS="gcc 12 clang 12 cmake 12"  # Non valid values
     
       
-language: minimal
+language: python
 before_install:
   - |
     count=`git diff --name-only $TRAVIS_COMMIT_RANGE | sort -u | uniq | grep docker_images | wc -l`

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ script:
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
   # Run tests outside the docker image
-  - . /home/tests/run_outside_tests.sh
+  - . $(pwd)/docker_images/_tests/run_outside_tests.sh
   # Run some tests inside the image
   - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
   # Run tests outside the docker image
   - . $(pwd)/docker_images/_tests/run_outside_tests.sh $(pwd)/docker_images/_tests/test_$IMAGE/
   # Run some tests inside the image
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE $DOCKER_USERNAME/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE --env DOCKER_USERNAME=$DOCKER_USERNAME $DOCKER_USERNAME/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
     - name: conanio/ci-functional
       env: 
        - IMAGE=ci-functional
+       - IMAGE_ARGS=gcc 12 clang 12 cmake 12
     
       
 language: minimal
@@ -59,7 +60,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE gcc 12 clang 12 -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE $IMAGE_ARGS -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,21 +25,12 @@ jobs:
       after_success:
 
     # Generate docker images (only if modified)
-<<<<<<< HEAD
-    - stage: docker
-      name: conanio/conantests
-      env: 
-        - IMAGE=conantests
-        - LINTER=false
-    - name: conanio/ci-unittests
-=======
     #- stage: docker conanio/conantests
     #  env: 
     #    - IMAGE=conan_tests
     #    - LINTER=false
     - stage: docker
       name: conanio/ci-unittests
->>>>>>> let's run tests inside docker images
       env: 
         - IMAGE=ci-unittests
     - name: conanio/ci-functional

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PYTHON=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "source /root/environment.sh && export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
+  - docker run -v "$(pwd)/docker_images/_tests:/home/tests" --env IMAGE=$IMAGE conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
   - docker build -t travis-ci-$IMAGE docker_images/$IMAGE
   - docker images
   - docker tag travis-ci-$IMAGE conanio/$IMAGE
-  - docker exec travis-ci-$IMAGE -v docker_images/_tests:/home/tests /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
+  - docker run -t -v "$(pwd)/docker_images/_tests:/home/tests" conanio/$IMAGE /bin/bash -c "export PY_DEFAULT=\$PY38 && IMAGE=$IMAGE && /home/tests/run_tests.sh"
 
 after_success:
   - |

--- a/docker_images/README.md
+++ b/docker_images/README.md
@@ -1,0 +1,17 @@
+# Docker images
+
+## ci-unittests
+
+This image contains only Python, **no system tools are available (there is no git, cmake or compiler)**.
+It provides several python versions that can be referenced using environment variables like PY27,
+PY35, PY37,...
+
+## ci-functional
+
+This image contains the same Python versions as the one above, and also **system tools** like Git, CMake,
+GCC or Clang. The installed versions are available using environment variables and they can also
+be installed when starting the container:
+
+```
+docker run -it travis-ci-ci-functional:latest gcc 7 clang 9 cmake 3.16.4
+```

--- a/docker_images/README.md
+++ b/docker_images/README.md
@@ -10,7 +10,7 @@ PY35, PY37,...
 
 This image contains the same Python versions as `ci-unittests`, but it also contains **system tools**
 like Git, CMake, GCC or Clang. The installed versions are available using environment variables and
-they can also be installed when starting the container:
+they can also be installed like the preferred alternative when starting the container:
 
 ```
 docker run -it travis-ci-ci-functional:latest gcc 7 clang 9 cmake 3.16.4

--- a/docker_images/README.md
+++ b/docker_images/README.md
@@ -8,9 +8,9 @@ PY35, PY37,...
 
 ## ci-functional
 
-This image contains the same Python versions as `ci-unittests`, and **system tools** like Git, CMake,
-GCC or Clang. The installed versions are available using environment variables and they can also
-be installed when starting the container:
+This image contains the same Python versions as `ci-unittests`, but it also contains **system tools**
+like Git, CMake, GCC or Clang. The installed versions are available using environment variables and
+they can also be installed when starting the container:
 
 ```
 docker run -it travis-ci-ci-functional:latest gcc 7 clang 9 cmake 3.16.4

--- a/docker_images/README.md
+++ b/docker_images/README.md
@@ -10,7 +10,7 @@ PY35, PY37,...
 
 This image contains the same Python versions as `ci-unittests`, but it also contains **system tools**
 like Git, CMake, GCC or Clang. The installed versions are available using environment variables and
-they can also be installed like the preferred alternative when starting the container:
+they can also be selected as the preferred alternative when starting the container:
 
 ```
 docker run -it travis-ci-ci-functional:latest gcc 7 clang 9 cmake 3.16.4

--- a/docker_images/README.md
+++ b/docker_images/README.md
@@ -8,7 +8,7 @@ PY35, PY37,...
 
 ## ci-functional
 
-This image contains the same Python versions as the one above, and also **system tools** like Git, CMake,
+This image contains the same Python versions as `ci-unittests`, and **system tools** like Git, CMake,
 GCC or Clang. The installed versions are available using environment variables and they can also
 be installed when starting the container:
 

--- a/docker_images/_tests/run_outside_tests.sh
+++ b/docker_images/_tests/run_outside_tests.sh
@@ -1,6 +1,6 @@
 echo "Running from outside docker image $IMAGE"
 python3 -m pip install -U pip
 python3 -m pip install pytest parameterized
-python3 -m pytest -m outside /home/tests/test_$IMAGE/
+python3 -m pytest -m outside $1
 
 # It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/run_outside_tests.sh
+++ b/docker_images/_tests/run_outside_tests.sh
@@ -1,6 +1,6 @@
 echo "Running from outside docker image $IMAGE"
 python3 -m pip install -U pip
-python3 -m pip install pytest parameterized
+python3 -m pip install pytest parameterized packaging
 python3 -m pytest -m outside $1
 
 # It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/run_outside_tests.sh
+++ b/docker_images/_tests/run_outside_tests.sh
@@ -1,0 +1,6 @@
+echo "Running from outside docker image $IMAGE"
+python3 -m pip install -U pip
+python3 -m pip install pytest parameterized
+python3 -m pytest -m outside /home/tests/test_$IMAGE/
+
+# It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -1,3 +1,4 @@
-echo "Running tests"
-$PY_DEFAULT -m pip install pytest
-$PY_DEFAULT -m pytest test_$IMAGE/
+echo "Running tests using $PYTHON"
+$PYTHON -m pip install -U pip
+$PYTHON -m pip install pytest parameterized
+$PYTHON -m pytest /home/tests/test_$IMAGE/

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -1,0 +1,3 @@
+echo "Running tests"
+$PY_DEFAULT -m pip install pytest
+$PY_DEFAULT -m pytest test_$IMAGE

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -1,3 +1,3 @@
 echo "Running tests"
 $PY_DEFAULT -m pip install pytest
-$PY_DEFAULT -m pytest test_$IMAGE
+$PY_DEFAULT -m pytest test_$IMAGE/

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -2,3 +2,5 @@ echo "Running tests using $PYTHON"
 $PYTHON -m pip install -U pip
 $PYTHON -m pip install pytest parameterized
 $PYTHON -m pytest /home/tests/test_$IMAGE/
+
+# It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -1,6 +1,6 @@
 echo "Running tests using $PYTHON"
 $PYTHON -m pip install -U pip
 $PYTHON -m pip install pytest parameterized
-$PYTHON -m pytest -v -m "not outside" /home/tests/test_$IMAGE/
+$PYTHON -m pytest -m "not outside" /home/tests/test_$IMAGE/
 
 # It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/run_tests.sh
+++ b/docker_images/_tests/run_tests.sh
@@ -1,6 +1,6 @@
 echo "Running tests using $PYTHON"
 $PYTHON -m pip install -U pip
 $PYTHON -m pip install pytest parameterized
-$PYTHON -m pytest /home/tests/test_$IMAGE/
+$PYTHON -m pytest -v -m "not outside" /home/tests/test_$IMAGE/
 
 # It is not a problem if this file modifies the image, any modification will be discarded

--- a/docker_images/_tests/test_ci-functional/test_clang.py
+++ b/docker_images/_tests/test_ci-functional/test_clang.py
@@ -6,9 +6,29 @@ import unittest
 from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
+clangxx_7 = os.environ["CLANGXX_7"]
+clang_7 = os.environ["CLANG_7"]
+clangxx_9 = os.environ["CLANGXX_9"]
+clang_9 = os.environ["CLANG_9"]
+
 
 class ClangTestCase(unittest.TestCase):
     """ Check Clang versions exist and work: clang-9 """
+
+    def test_clang7_versions(self):
+        expected = "7.0.1"
+        for it in [clangxx_7, clang_7]:
+            out, _ = subprocess.Popen([it, '--version'], stdout=subprocess.PIPE).communicate()
+            first_line = out.splitlines()[0]
+            # clang version 7.0.1-9build1 (tags/RELEASE_701/final)
+            self.assertEqual(first_line.decode(), f'clang version {expected}-9build1 (tags/RELEASE_701/final)')
+
+    def test_gcc9_versions(self):
+        # Clang 9 returns the proper version for '-dumpversion' command
+        expected = "9.0.0"
+        for it in [clangxx_9, clang_9]:
+            out, _ = subprocess.Popen([it, '-dumpversion'], stdout=subprocess.PIPE).communicate()
+            self.assertEqual(out.decode().strip(), expected)
 
     @staticmethod
     def _grep_cplusplus(cmd):
@@ -19,7 +39,7 @@ class ClangTestCase(unittest.TestCase):
         return out.strip()
 
     def test_clang9_default(self):
-        cmd = f"clang-9 -dM -E -x c++ /dev/null"
+        cmd = f"{clang_9} -dM -E -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
@@ -29,12 +49,12 @@ class ClangTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),
                            ("-std=c++2a", "201707L"),])
     def test_clang9(self, std_flag, std_output):
-        cmd = f"clang-9 -dM -E {std_flag} -x c++ /dev/null"
+        cmd = f"{clang_9} -dM -E {std_flag} -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_clang7_default(self):
-        cmd = f"clang-7 -dM -E -x c++ /dev/null"
+        cmd = f"{clang_7} -dM -E -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
@@ -44,6 +64,6 @@ class ClangTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),
                            ("-std=c++2a", "201707L"),])
     def test_clang7(self, std_flag, std_output):
-        cmd = f"clang-7 -dM -E {std_flag} -x c++ /dev/null"
+        cmd = f"{clang_7} -dM -E {std_flag} -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')

--- a/docker_images/_tests/test_ci-functional/test_clang.py
+++ b/docker_images/_tests/test_ci-functional/test_clang.py
@@ -12,7 +12,7 @@ class ClangTestCase(unittest.TestCase):
 
     def test_clang9_default(self):
         cmd = f"clang-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -22,12 +22,12 @@ class ClangTestCase(unittest.TestCase):
                            ("-std=c++2a", "201709L"),])
     def test_clang9(self, std_flag, std_output):
         cmd = f"clang-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_clang7_default(self):
         cmd = f"clang-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -37,5 +37,5 @@ class ClangTestCase(unittest.TestCase):
                            ("-std=c++2a", "201707L"),])
     def test_clang7(self, std_flag, std_output):
         cmd = f"clang-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')

--- a/docker_images/_tests/test_ci-functional/test_clang.py
+++ b/docker_images/_tests/test_ci-functional/test_clang.py
@@ -1,0 +1,41 @@
+import os
+import re
+import subprocess
+import unittest
+
+from packaging.version import VERSION_PATTERN, parse
+from parameterized import parameterized
+
+
+class ClangTestCase(unittest.TestCase):
+    """ Check Clang versions exist and work: clang-9 """
+
+    def test_clang9_default(self):
+        cmd = f"clang-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
+
+    @parameterized.expand([("-std=c++98", "199711L"),
+                           ("-std=c++11", "201103L"),
+                           ("-std=c++14", "201402L"),
+                           ("-std=c++17", "201703L"),
+                           ("-std=c++2a", "201709L"),])
+    def test_clang9(self, std_flag, std_output):
+        cmd = f"clang-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
+
+    def test_clang7_default(self):
+        cmd = f"clang-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
+
+    @parameterized.expand([("-std=c++98", "199711L"),
+                           ("-std=c++11", "201103L"),
+                           ("-std=c++14", "201402L"),
+                           ("-std=c++17", "201703L"),
+                           ("-std=c++2a", "201707L"),])
+    def test_clang7(self, std_flag, std_output):
+        cmd = f"clang-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')

--- a/docker_images/_tests/test_ci-functional/test_clang.py
+++ b/docker_images/_tests/test_ci-functional/test_clang.py
@@ -6,10 +6,10 @@ import unittest
 from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
-clangxx_7 = os.environ["CLANGXX_7"]
-clang_7 = os.environ["CLANG_7"]
-clangxx_9 = os.environ["CLANGXX_9"]
-clang_9 = os.environ["CLANG_9"]
+clangxx_7 = os.environ.get("CLANGXX_7", None)
+clang_7 = os.environ.get("CLANG_7", None)
+clangxx_9 = os.environ.get("CLANGXX_9", None)
+clang_9 = os.environ.get("CLANG_9", None)
 
 
 class ClangTestCase(unittest.TestCase):

--- a/docker_images/_tests/test_ci-functional/test_clang.py
+++ b/docker_images/_tests/test_ci-functional/test_clang.py
@@ -10,24 +10,32 @@ from parameterized import parameterized
 class ClangTestCase(unittest.TestCase):
     """ Check Clang versions exist and work: clang-9 """
 
+    @staticmethod
+    def _grep_cplusplus(cmd):
+        p1 = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['grep', '-F', '__cplusplus'], stdin=p1.stdout, stdout=subprocess.PIPE)
+        p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
+        out, _ = p2.communicate()
+        return out.strip()
+
     def test_clang9_default(self):
-        cmd = f"clang-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"clang-9 -dM -E -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
                            ("-std=c++11", "201103L"),
                            ("-std=c++14", "201402L"),
                            ("-std=c++17", "201703L"),
-                           ("-std=c++2a", "201709L"),])
+                           ("-std=c++2a", "201707L"),])
     def test_clang9(self, std_flag, std_output):
-        cmd = f"clang-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"clang-9 -dM -E {std_flag} -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_clang7_default(self):
-        cmd = f"clang-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"clang-7 -dM -E -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -36,6 +44,6 @@ class ClangTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),
                            ("-std=c++2a", "201707L"),])
     def test_clang7(self, std_flag, std_output):
-        cmd = f"clang-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"clang-7 -dM -E {std_flag} -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')

--- a/docker_images/_tests/test_ci-functional/test_cmake.py
+++ b/docker_images/_tests/test_ci-functional/test_cmake.py
@@ -1,0 +1,19 @@
+import os
+import re
+import subprocess
+import unittest
+
+from packaging.version import VERSION_PATTERN, parse
+from parameterized import parameterized
+
+
+class CMakeTestCase(unittest.TestCase):
+    """ Check CMake versions exist and work"""
+
+    @parameterized.expand([("CMAKE_3_16_4", "3.16.4"),
+                           ("CMAKE_3_16_3", "3.16.3"),])
+    def test_versions(self, envvar, version):
+        cmake_bin = os.environ[envvar]
+        out, _ = subprocess.Popen([cmake_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        first_line = out.splitlines()[0]
+        self.assertEqual(first_line.decode().strip(), f'cmake version {version}')

--- a/docker_images/_tests/test_ci-functional/test_gcc.py
+++ b/docker_images/_tests/test_ci-functional/test_gcc.py
@@ -7,10 +7,10 @@ from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
 
-gxx_7 = os.environ["GXX_7"]
-gcc_7 = os.environ["GCC_7"]
-gxx_9 = os.environ["GXX_9"]
-gcc_9 = os.environ["GCC_9"]
+gxx_7 = os.environ.get("GXX_7", None)
+gcc_7 = os.environ.get("GCC_7", None)
+gxx_9 = os.environ.get("GXX_9", None)
+gcc_9 = os.environ.get("GCC_9", None)
 
 
 class GCCTestCase(unittest.TestCase):

--- a/docker_images/_tests/test_ci-functional/test_gcc.py
+++ b/docker_images/_tests/test_ci-functional/test_gcc.py
@@ -1,0 +1,42 @@
+import os
+import re
+import subprocess
+import unittest
+
+from packaging.version import VERSION_PATTERN, parse
+from parameterized import parameterized
+
+
+class GCCTestCase(unittest.TestCase):
+    """ Check GCC versions exist and work: GCC-7 and GCC-9 """
+
+    def test_gcc9_default(self):
+        cmd = f"g++-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
+
+    @parameterized.expand([("-std=c++98", "199711L"),
+                           ("-std=c++11", "201103L"),
+                           ("-std=c++14", "201402L"),
+                           ("-std=c++17", "201703L"),
+                           ("-std=c++2a", "201709L"),])
+    def test_gcc9(self, std_flag, std_output):
+        cmd = f"g++-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
+
+    def test_gcc7_default(self):
+        cmd = f"g++-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
+
+    @parameterized.expand([("-std=c++98", "199711L"),
+                           ("-std=c++11", "201103L"),
+                           ("-std=c++14", "201402L"),
+                           ("-std=c++17", "201703L"),])
+    def test_gcc7(self, std_flag, std_output):
+        cmd = f"g++-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
+        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
+
+

--- a/docker_images/_tests/test_ci-functional/test_gcc.py
+++ b/docker_images/_tests/test_ci-functional/test_gcc.py
@@ -7,8 +7,28 @@ from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
 
+gxx_7 = os.environ["GXX_7"]
+gcc_7 = os.environ["GCC_7"]
+gxx_9 = os.environ["GXX_9"]
+gcc_9 = os.environ["GCC_9"]
+
+
 class GCCTestCase(unittest.TestCase):
     """ Check GCC versions exist and work: GCC-7 and GCC-9 """
+
+    def test_gcc7_versions(self):
+        expected = "7"
+        out, _ = subprocess.Popen([gxx_7, '-dumpversion'], stdout=subprocess.PIPE).communicate()
+        self.assertEqual(out.decode().strip(), expected)
+        out, _ = subprocess.Popen([gcc_7, '-dumpversion'], stdout=subprocess.PIPE).communicate()
+        self.assertEqual(out.decode().strip(), expected)
+
+    def test_gcc9_versions(self):
+        expected = "9"
+        out, _ = subprocess.Popen([gxx_9, '-dumpversion'], stdout=subprocess.PIPE).communicate()
+        self.assertEqual(out.decode().strip(), expected)
+        out, _ = subprocess.Popen([gcc_9, '-dumpversion'], stdout=subprocess.PIPE).communicate()
+        self.assertEqual(out.decode().strip(), expected)
 
     @staticmethod
     def _grep_cplusplus(cmd):
@@ -19,7 +39,7 @@ class GCCTestCase(unittest.TestCase):
         return out.strip()
 
     def test_gcc9_default(self):
-        cmd = f"g++-9 -dM -E -x c++ /dev/null"
+        cmd = f"{gxx_9} -dM -E -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
@@ -29,12 +49,12 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),
                            ("-std=c++2a", "201709L"),])
     def test_gcc9(self, std_flag, std_output):
-        cmd = f"g++-9 -dM -E {std_flag} -x c++ /dev/null"
+        cmd = f"{gxx_9} -dM -E {std_flag} -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_gcc7_default(self):
-        cmd = f"g++-7 -dM -E -x c++ /dev/null"
+        cmd = f"{gxx_7} -dM -E -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
@@ -43,7 +63,7 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++14", "201402L"),
                            ("-std=c++17", "201703L"),])
     def test_gcc7(self, std_flag, std_output):
-        cmd = f"g++-7 -dM -E {std_flag} -x c++ /dev/null"
+        cmd = f"{gxx_7} -dM -E {std_flag} -x c++ /dev/null"
         out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 

--- a/docker_images/_tests/test_ci-functional/test_gcc.py
+++ b/docker_images/_tests/test_ci-functional/test_gcc.py
@@ -10,9 +10,17 @@ from parameterized import parameterized
 class GCCTestCase(unittest.TestCase):
     """ Check GCC versions exist and work: GCC-7 and GCC-9 """
 
+    @staticmethod
+    def _grep_cplusplus(cmd):
+        p1 = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(['grep', '-F', '__cplusplus'], stdin=p1.stdout, stdout=subprocess.PIPE)
+        p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
+        out, _ = p2.communicate()
+        return out.strip()
+
     def test_gcc9_default(self):
-        cmd = f"g++-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"g++-9 -dM -E -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -21,13 +29,13 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),
                            ("-std=c++2a", "201709L"),])
     def test_gcc9(self, std_flag, std_output):
-        cmd = f"g++-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"g++-9 -dM -E {std_flag} -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_gcc7_default(self):
-        cmd = f"g++-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"g++-7 -dM -E -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -35,8 +43,8 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++14", "201402L"),
                            ("-std=c++17", "201703L"),])
     def test_gcc7(self, std_flag, std_output):
-        cmd = f"g++-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
+        cmd = f"g++-7 -dM -E {std_flag} -x c++ /dev/null"
+        out = self._grep_cplusplus(cmd.split())
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
 

--- a/docker_images/_tests/test_ci-functional/test_gcc.py
+++ b/docker_images/_tests/test_ci-functional/test_gcc.py
@@ -12,7 +12,7 @@ class GCCTestCase(unittest.TestCase):
 
     def test_gcc9_default(self):
         cmd = f"g++-9 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -22,12 +22,12 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++2a", "201709L"),])
     def test_gcc9(self, std_flag, std_output):
         cmd = f"g++-9 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
     def test_gcc7_default(self):
         cmd = f"g++-7 -dM -E -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), '#define __cplusplus 201402L')  # This is C++14
 
     @parameterized.expand([("-std=c++98", "199711L"),
@@ -36,7 +36,7 @@ class GCCTestCase(unittest.TestCase):
                            ("-std=c++17", "201703L"),])
     def test_gcc7(self, std_flag, std_output):
         cmd = f"g++-7 -dM -E {std_flag} -x c++ /dev/null | grep -F __cplusplus"
-        out, _ = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False).communicate()
         self.assertEqual(out.decode(), f'#define __cplusplus {std_output}')
 
 

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -22,10 +22,11 @@ class OutsideDockerTests(unittest.TestCase):
         last_line = out.splitlines()[-1]
         self.assertEqual(last_line.decode().strip(), gcc_version)
 
-    @parameterized.expand([("7", "7.0.1"), ("9", "9.0.0"), ])
+    @parameterized.expand([("7", "7.0.1-9build1 (tags/RELEASE_701/final)"), 
+                           ("9", "9.0.0-2 (tags/RELEASE_900/final)"), ])
     def test_change_clang_version(self, clang_version, expected):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', clang_version, 'cmake', '3.16.4', '-c', 'clang --version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertIn(f'clang version {expected}-9build1 (tags/RELEASE_701/final)', out.decode())
+        self.assertIn(f'clang version {expected}', out.decode())
 
     @parameterized.expand([("3.16.4", ), ("3.16.3", ), ])
     def test_change_cmake_version(self, cmake_version):

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -11,24 +11,25 @@ import pytest
 
 @pytest.mark.outside
 class OutsideDockerTests(unittest.TestCase):
+    docker_image = f'{os.environ["DOCKER_USERNAME"]}/{os.environ["IMAGE"]}'
 
     def test_functional_image(self):
-        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', self.docker_image, 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())
 
     @parameterized.expand([("7", ), ("9", ), ])
     def test_change_gcc_version(self, gcc_version):
-        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', gcc_version, 'clang', '9', 'cmake', '3.16.4', '-c', 'gcc -dumpversion'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', self.docker_image, 'gcc', gcc_version, 'clang', '9', 'cmake', '3.16.4', '-c', 'gcc -dumpversion'], stdout=subprocess.PIPE, shell=False).communicate()
         last_line = out.splitlines()[-1]
         self.assertEqual(last_line.decode().strip(), gcc_version)
 
     @parameterized.expand([("7", "7.0.1-9build1 (tags/RELEASE_701/final)"), 
                            ("9", "9.0.0-2 (tags/RELEASE_900/final)"), ])
     def test_change_clang_version(self, clang_version, expected):
-        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', clang_version, 'cmake', '3.16.4', '-c', 'clang --version'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', self.docker_image, 'gcc', '7', 'clang', clang_version, 'cmake', '3.16.4', '-c', 'clang --version'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn(f'clang version {expected}', out.decode())
 
     @parameterized.expand([("3.16.4", ), ("3.16.3", ), ])
     def test_change_cmake_version(self, cmake_version):
-        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', cmake_version, '-c', 'cmake --version'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', self.docker_image, 'gcc', '7', 'clang', '9', 'cmake', cmake_version, '-c', 'cmake --version'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn(f'cmake version {cmake_version}', out.decode())

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -19,15 +19,16 @@ class OutsideDockerTests(unittest.TestCase):
     @parameterized.expand([("7", ), ("9", ), ])
     def test_change_gcc_version(self, gcc_version):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', gcc_version, 'clang', '9', 'cmake', '3.16.4', '-c', 'gcc -dumpversion'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertEqual(out.decode().strip(), gcc_version)
+        last_line = out.splitlines()[-1]
+        self.assertEqual(last_line.decode().strip(), gcc_version)
 
     @parameterized.expand([("7", "7.0.1"), ("9", "9.0.0"), ])
     def test_change_clang_version(self, clang_version, expected):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', clang_version, 'cmake', '3.16.4', '-c', 'clang --version'], stdout=subprocess.PIPE, shell=False).communicate()
-        first_line = out.splitlines()[0]
-        self.assertEqual(first_line.decode(), f'clang version {expected}-9build1 (tags/RELEASE_701/final)')
+        self.assertIn(f'clang version {expected}-9build1 (tags/RELEASE_701/final)', out.decode())
 
     @parameterized.expand([("3.16.4", ), ("3.16.3", ), ])
     def test_change_cmake_version(self, cmake_version):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', cmake_version, '-c', 'cmake --version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertEqual(out.decode().strip(), f'cmake version {cmake_version}')
+        last_line = out.splitlines()[-1]
+        self.assertEqual(last_line.decode().strip(), f'cmake version {cmake_version}')

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -15,3 +15,19 @@ class OutsideDockerTests(unittest.TestCase):
     def test_functional_image(self):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())
+
+    @parameterized.expand([("7", ), ("9", ), ])
+    def test_change_gcc_version(self, gcc_version):
+        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', gcc_version, 'clang', '9', 'cmake', '3.16.4', '-c', 'gcc -dumpversion'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode().strip(), gcc_version)
+
+    @parameterized.expand([("7", "7.0.1"), ("9", "9.0.0"), ])
+    def test_change_clang_version(self, clang_version, expected):
+        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', clang_version, 'cmake', '3.16.4', '-c', 'clang --version'], stdout=subprocess.PIPE, shell=False).communicate()
+        first_line = out.splitlines()[0]
+        self.assertEqual(first_line.decode(), f'clang version {expected}-9build1 (tags/RELEASE_701/final)')
+
+    @parameterized.expand([("3.16.4", ), ("3.16.3", ), ])
+    def test_change_cmake_version(self, cmake_version):
+        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', cmake_version, '-c', 'cmake --version'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertEqual(out.decode().strip(), f'cmake version {cmake_version}')

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -1,8 +1,23 @@
+import os
+import re
+import subprocess
 import unittest
+
+from packaging.version import VERSION_PATTERN, parse
+from parameterized import parameterized
+
 import pytest
 
 
 @pytest.mark.outside
 class OutsideDockerTests(unittest.TestCase):
-    def test_entrypoint(self):
-        self.fail("Not expected to run")
+
+    @pytest.mark.skipif(os.environ["IMAGE"] != "ci-unittests", reason="Tests only for image 'ci-unittests'")
+    def test_unittests_image(self):
+        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertIn("DISTRIB_ID=Ubuntu", out.decode())
+
+    @pytest.mark.skipif(os.environ["IMAGE"] != "ci-functional", reason="Tests only for image 'ci-functional'")
+    def test_functional_image(self):
+        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertIn("DISTRIB_ID=Ubuntu", out.decode())

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -13,5 +13,5 @@ import pytest
 class OutsideDockerTests(unittest.TestCase):
 
     def test_functional_image(self):
-        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -1,0 +1,8 @@
+import unittest
+import pytest
+
+
+@pytest.mark.outside
+class OutsideDockerTests(unittest.TestCase):
+    def test_entrypoint(self):
+        self.fail("Not expected to run")

--- a/docker_images/_tests/test_ci-functional/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-functional/test_outside_docker.py
@@ -30,5 +30,4 @@ class OutsideDockerTests(unittest.TestCase):
     @parameterized.expand([("3.16.4", ), ("3.16.3", ), ])
     def test_change_cmake_version(self, cmake_version):
         out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', cmake_version, '-c', 'cmake --version'], stdout=subprocess.PIPE, shell=False).communicate()
-        last_line = out.splitlines()[-1]
-        self.assertEqual(last_line.decode().strip(), f'cmake version {cmake_version}')
+        self.assertIn(f'cmake version {cmake_version}', out.decode())

--- a/docker_images/_tests/test_ci-functional/test_python_versions.py
+++ b/docker_images/_tests/test_ci-functional/test_python_versions.py
@@ -1,0 +1,30 @@
+import os
+import re
+import subprocess
+import unittest
+
+from packaging.version import VERSION_PATTERN, parse
+from parameterized import parameterized
+
+
+class PythonVersionsTestCase(unittest.TestCase):
+    """ Check Python versions are available and environment variables """
+
+    re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
+
+    def test_py2_envar(self):
+        """ Look for PY27 env variable and check version """
+        python_bin = os.environ["PY27"]
+        out, _ = subprocess.Popen([python_bin, '-c', 'import sys; print(sys.version)'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertRegex(out.decode(), r'^2\.7\.\d+\s')
+
+    @parameterized.expand([("PY35", (3, 5)),
+                           ("PY37", (3, 7)),
+                           ("PY38", (3, 8)),])
+    def test_python_envvars(self, env_var, version):
+        python_bin = os.environ[env_var]
+        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        m = self.re_py_version.match(out.decode())
+        v = parse(m.group(1))
+        self.assertEqual(v.release[0], version[0])
+        self.assertEqual(v.release[1], version[1])

--- a/docker_images/_tests/test_ci-unittests/__init__.py
+++ b/docker_images/_tests/test_ci-unittests/__init__.py
@@ -1,5 +1,1 @@
-import unittest
 
-class CIUnittestsTestCase(unittest.TestCase):
-    
-    def test_

--- a/docker_images/_tests/test_ci-unittests/__init__.py
+++ b/docker_images/_tests/test_ci-unittests/__init__.py
@@ -1,0 +1,5 @@
+import unittest
+
+class CIUnittestsTestCase(unittest.TestCase):
+    
+    def test_

--- a/docker_images/_tests/test_ci-unittests/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-unittests/test_outside_docker.py
@@ -4,7 +4,6 @@ import subprocess
 import unittest
 
 from packaging.version import VERSION_PATTERN, parse
-from parameterized import parameterized
 
 import pytest
 

--- a/docker_images/_tests/test_ci-unittests/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-unittests/test_outside_docker.py
@@ -10,7 +10,8 @@ import pytest
 
 @pytest.mark.outside
 class OutsideDockerTests(unittest.TestCase):
+    docker_image = f'{os.environ["DOCKER_USERNAME"]}/{os.environ["IMAGE"]}'
 
     def test_unittests_image(self):
-        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', self.docker_image, '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())

--- a/docker_images/_tests/test_ci-unittests/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-unittests/test_outside_docker.py
@@ -12,6 +12,6 @@ import pytest
 @pytest.mark.outside
 class OutsideDockerTests(unittest.TestCase):
 
-    def test_functional_image(self):
-        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], 'gcc', '7', 'clang', '9', 'cmake', '3.16.4', '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+    def test_unittests_image(self):
+        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())

--- a/docker_images/_tests/test_ci-unittests/test_outside_docker.py
+++ b/docker_images/_tests/test_ci-unittests/test_outside_docker.py
@@ -13,5 +13,5 @@ import pytest
 class OutsideDockerTests(unittest.TestCase):
 
     def test_unittests_image(self):
-        out, _ = subprocess.Popen(['docker', 'run', os.environ["IMAGE"], '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
+        out, _ = subprocess.Popen(['docker', 'run', 'conanio/' + os.environ["IMAGE"], '-c', 'cat /etc/lsb-release'], stdout=subprocess.PIPE, shell=False).communicate()
         self.assertIn("DISTRIB_ID=Ubuntu", out.decode())

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -1,7 +1,28 @@
 import unittest
+import os
+import subprocess
+
 
 class CIUnittestsTestCase(unittest.TestCase):
+    """ Check Python versions are available and environment variables """
     
-    def test_base(self):
-        self.assertTrue(2+3, 5)
-        self.assertTrue(2+3, 5)
+    def test_py27(self):
+        python_bin = os.environ["PY27"]
+        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertTrue(out.startswith("Python 2.7"))
+
+    def test_py35(self):
+        python_bin = os.environ["PY35"]
+        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertTrue(out.startswith("Python 3.5"))
+
+    def test_py37(self):
+        python_bin = os.environ["PY37"]
+        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertTrue(out.startswith("Python 3.7"))
+
+    def test_py38(self):
+        python_bin = os.environ["PY38"]
+        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertTrue(out.startswith("Python 3.8"))
+

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -1,28 +1,24 @@
-import unittest
 import os
+import re
 import subprocess
+import unittest
+
+from packaging.version import parse, VERSION_PATTERN
+from parameterized import parameterized
 
 
 class CIUnittestsTestCase(unittest.TestCase):
     """ Check Python versions are available and environment variables """
-    
-    def test_py27(self):
-        python_bin = os.environ["PY27"]
-        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertTrue(out.startswith("Python 2.7"))
 
-    def test_py35(self):
-        python_bin = os.environ["PY35"]
-        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertTrue(out.startswith("Python 3.5"))
+    re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
 
-    def test_py37(self):
-        python_bin = os.environ["PY37"]
+    @parameterized.expand(["PY27", "2.7"], 
+                          ["PY35", "3.5"], 
+                          ["PY37", "3.7"], 
+                          ["PY38", "3.8"], )
+    def test_environment_variables(self, env_var, version):
+        python_bin = os.environ[env_var]
         out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertTrue(out.startswith("Python 3.7"))
-
-    def test_py38(self):
-        python_bin = os.environ["PY38"]
-        out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
-        self.assertTrue(out.startswith("Python 3.8"))
-
+        m = self.re_py_version.match(out)
+        v = parse(m.group(1))
+        self.assertGreaterEqual(v, parse(version))

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -28,19 +28,3 @@ class PythonVersionsTestCase(unittest.TestCase):
         v = parse(m.group(1))
         self.assertEqual(v.release[0], version[0])
         self.assertEqual(v.release[1], version[1])
-
-
-class SystemToolsTestCase(unittest.TestCase):
-    """ This image doesn't have any system tool """
-
-    def test_cmake_not_available(self):
-        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'cmake'"):
-            subprocess.Popen(['cmake',]).communicate()
-
-    def test_git_not_available(self):
-        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'git'"):
-            subprocess.Popen(['git',]).communicate()
-
-    def test_gcc_not_available(self):
-        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'gcc'"):
-            subprocess.Popen(['gcc',]).communicate()

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -16,9 +16,21 @@ class CIUnittestsTestCase(unittest.TestCase):
                           ["PY35", "3.5"], 
                           ["PY37", "3.7"], 
                           ["PY38", "3.8"], )
-    def test_environment_variables(self, env_var, version):
+    def test_python_envvars(self, env_var, version):
         python_bin = os.environ[env_var]
         out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
         m = self.re_py_version.match(out)
         v = parse(m.group(1))
         self.assertGreaterEqual(v, parse(version))
+
+    def test_cmake_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'cmake'"):
+            subprocess.Popen(['cmake',]).communicate()
+
+    def test_git_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'git'"):
+            subprocess.Popen(['git',]).communicate()
+
+    def test_gcc_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'gcc'"):
+            subprocess.Popen(['gcc',]).communicate()

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -12,10 +12,10 @@ class CIUnittestsTestCase(unittest.TestCase):
 
     re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
 
-    @parameterized.expand(["PY27", (2, 7)],
-                          ["PY35", (3, 5)],
-                          ["PY37", (3, 7)],
-                          ["PY38", (3, 8)], )
+    @parameterized.expand([("PY27", (2, 7)),
+                           ("PY35", (3, 5)),
+                           ("PY37", (3, 7)),
+                           ("PY38", (3, 8)),])
     def test_python_envvars(self, env_var, version):
         python_bin = os.environ[env_var]
         out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -7,13 +7,18 @@ from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
 
-class CIUnittestsTestCase(unittest.TestCase):
+class PythonVersionsTestCase(unittest.TestCase):
     """ Check Python versions are available and environment variables """
 
     re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
 
-    @parameterized.expand([("PY27", (2, 7)),
-                           ("PY35", (3, 5)),
+    def test_py2_envar(self):
+        """ Look for PY27 env variable and check version """
+        python_bin = os.environ["PY27"]
+        out, _ = subprocess.Popen([python_bin, '-c', 'import sys; print(sys.version)'], stdout=subprocess.PIPE, shell=False).communicate()
+        self.assertRegex(out.decode(), r'^2\.7\.\d+\s')
+
+    @parameterized.expand([("PY35", (3, 5)),
                            ("PY37", (3, 7)),
                            ("PY38", (3, 8)),])
     def test_python_envvars(self, env_var, version):
@@ -23,6 +28,10 @@ class CIUnittestsTestCase(unittest.TestCase):
         v = parse(m.group(1))
         self.assertEqual(v.release[0], version[0])
         self.assertEqual(v.release[1], version[1])
+
+
+class SystemToolsTestCase(unittest.TestCase):
+    """ This image doesn't have any system tool """
 
     def test_cmake_not_available(self):
         with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'cmake'"):

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -19,7 +19,7 @@ class CIUnittestsTestCase(unittest.TestCase):
     def test_python_envvars(self, env_var, version):
         python_bin = os.environ[env_var]
         out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
-        m = self.re_py_version.match(out)
+        m = self.re_py_version.match(out.decode())
         v = parse(m.group(1))
         self.assertEqual(v.release[0], version[0])
         self.assertEqual(v.release[1], version[1])

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -3,7 +3,7 @@ import re
 import subprocess
 import unittest
 
-from packaging.version import parse, VERSION_PATTERN
+from packaging.version import VERSION_PATTERN, parse
 from parameterized import parameterized
 
 

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -8,7 +8,7 @@ from parameterized import parameterized
 
 
 class PythonVersionsTestCase(unittest.TestCase):
-    """ Check Python versions are available and environment variables """
+    """ Check Python versions are available using environment variables """
 
     re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
 

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -12,16 +12,17 @@ class CIUnittestsTestCase(unittest.TestCase):
 
     re_py_version = re.compile(r'^Python (\d+\.\d+\.\d+)')
 
-    @parameterized.expand(["PY27", "2.7"], 
-                          ["PY35", "3.5"], 
-                          ["PY37", "3.7"], 
-                          ["PY38", "3.8"], )
+    @parameterized.expand(["PY27", (2, 7)],
+                          ["PY35", (3, 5)],
+                          ["PY37", (3, 7)],
+                          ["PY38", (3, 8)], )
     def test_python_envvars(self, env_var, version):
         python_bin = os.environ[env_var]
         out, _ = subprocess.Popen([python_bin, '--version'], stdout=subprocess.PIPE, shell=False).communicate()
         m = self.re_py_version.match(out)
         v = parse(m.group(1))
-        self.assertGreaterEqual(v, parse(version))
+        self.assertEqual(v.release[0], version[0])
+        self.assertEqual(v.release[1], version[1])
 
     def test_cmake_not_available(self):
         with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'cmake'"):

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -4,3 +4,4 @@ class CIUnittestsTestCase(unittest.TestCase):
     
     def test_base(self):
         self.assertTrue(2+3, 5)
+        self.assertTrue(2+3, 5)

--- a/docker_images/_tests/test_ci-unittests/test_python_versions.py
+++ b/docker_images/_tests/test_ci-unittests/test_python_versions.py
@@ -1,0 +1,6 @@
+import unittest
+
+class CIUnittestsTestCase(unittest.TestCase):
+    
+    def test_base(self):
+        self.assertTrue(2+3, 5)

--- a/docker_images/_tests/test_ci-unittests/test_system_tools.py
+++ b/docker_images/_tests/test_ci-unittests/test_system_tools.py
@@ -1,0 +1,24 @@
+import os
+import re
+import subprocess
+import unittest
+
+
+class SystemToolsTestCase(unittest.TestCase):
+    """ This image doesn't have any system tool """
+
+    def test_cmake_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'cmake'"):
+            subprocess.Popen(['cmake',]).communicate()
+
+    def test_git_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'git'"):
+            subprocess.Popen(['git',]).communicate()
+
+    def test_gcc_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'gcc'"):
+            subprocess.Popen(['gcc',]).communicate()
+
+    def test_clang_not_available(self):
+        with self.assertRaisesRegex(FileNotFoundError, "No such file or directory: 'clang'"):
+            subprocess.Popen(['clang',]).communicate()

--- a/docker_images/ci-functional/Dockerfile
+++ b/docker_images/ci-functional/Dockerfile
@@ -1,10 +1,36 @@
-FROM conanio/tests-base
+FROM ubuntu:eoan
 
 LABEL maintainer="Conan.io <info@conan.io>"
 
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV PY27 /root/.pyenv/versions/2.7.17/bin/python
+ENV PY35 /root/.pyenv/versions/3.5.9/bin/python
+ENV PY37 /root/.pyenv/versions/3.7.6/bin/python
+ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
+
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
-       ninja-build \
-       g++-9-multilib
- 
-RUN echo "/usr/bin/g++-9" >> /root/environment.sh
+       sudo ca-certificates \
+       # pyenv requires
+       make build-essential libssl-dev zlib1g-dev libbz2-dev \
+       libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+       xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
+    \
+    # Install pyenv stuff
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && export PATH="/root/.pyenv/bin:$PATH" \
+    && pyenv init - \
+    && pyenv virtualenv-init - \
+    && pyenv update \
+    && pyenv install 3.8.1 \
+    && pyenv install 3.7.6 \
+    && pyenv install 3.5.9 \
+    && pyenv install 2.7.17
+
+# Install compilers: g++ and clang++
+RUN apt-get -qq install -y --no-install-recommends \
+    clang-9 clang-7 \
+    g++-9-multilib g++-7-multilib
+
+#ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-functional/Dockerfile
+++ b/docker_images/ci-functional/Dockerfile
@@ -10,7 +10,7 @@ ENV PY37 /root/.pyenv/versions/3.7.6/bin/python
 ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 
 ENV CMAKE_3_16_4 /root/conan_packages/.conan/data/cmake/3.16.4/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake
-ENV CMAKE_3_16_3 /root/conan_packages/.conan/data/cmake/3.16.4/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake
+ENV CMAKE_3_16_3 /root/conan_packages/.conan/data/cmake/3.16.3/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake
 
 ENV GCC_7 /usr/bin/gcc-7
 ENV GXX_7 /usr/bin/g++-7

--- a/docker_images/ci-functional/Dockerfile
+++ b/docker_images/ci-functional/Dockerfile
@@ -1,0 +1,10 @@
+FROM conanio/tests-base
+
+LABEL maintainer="Conan.io <info@conan.io>"
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+       ninja-build \
+       g++-9-multilib
+ 
+RUN echo "/usr/bin/g++-9" >> /root/environment.sh

--- a/docker_images/ci-functional/Dockerfile
+++ b/docker_images/ci-functional/Dockerfile
@@ -9,6 +9,20 @@ ENV PY35 /root/.pyenv/versions/3.5.9/bin/python
 ENV PY37 /root/.pyenv/versions/3.7.6/bin/python
 ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 
+ENV CMAKE_3_16_4 /root/conan_packages/.conan/data/cmake/3.16.4/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake
+ENV CMAKE_3_16_3 /root/conan_packages/.conan/data/cmake/3.16.4/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake
+
+ENV GCC_7 /usr/bin/gcc-7
+ENV GXX_7 /usr/bin/g++-7
+ENV GCC_9 /usr/bin/gcc-9
+ENV GXX_9 /usr/bin/g++-9
+
+ENV CLANG_7 /usr/bin/clang-7
+ENV CLANGXX_7 /usr/bin/clang++-7
+ENV CLANG_9 /usr/bin/clang-9
+ENV CLANGXX_9 /usr/bin/clang++-9
+
+
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
        sudo ca-certificates \
@@ -27,6 +41,21 @@ RUN apt-get -qq update \
     && pyenv install 3.7.6 \
     && pyenv install 3.5.9 \
     && pyenv install 2.7.17
+
+# Install CMake versions (using Conan) and register alternatives
+RUN $PY38 -m venv ./conan_tmp && cd ./conan_tmp \
+    && ./bin/pip install conan \
+    && export CONAN_USER_HOME=/root/conan_packages/ \
+    && ./bin/conan install cmake/3.16.4@ \
+    && ./bin/conan install cmake/3.16.3@ \
+    && ./bin/pip uninstall -y conan \
+    && cd .. && rm -fr ./conan_tmp
+
+# Alternatives for CMake
+COPY select_cmake.sh /root/select_cmake.sh
+RUN chmod +x /root/select_cmake.sh \
+    && update-alternatives --install /usr/bin/cmake cmake /root/conan_packages/.conan/data/cmake/3.16.4/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake 10 \
+    && update-alternatives --install /usr/bin/cmake cmake /root/conan_packages/.conan/data/cmake/3.16.3/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake 20
 
 # Install compilers: g++ and clang++
 RUN apt-get -qq install -y --no-install-recommends \
@@ -52,4 +81,4 @@ RUN chmod +x /root/select_clang.sh &&\
 COPY select_alternatives.sh /root/select_alternatives.sh
 RUN chmod +x /root/select_alternatives.sh
 ENTRYPOINT ["/root/select_alternatives.sh" ]
-CMD ["gcc", "9", "clang", "9"]
+CMD ["gcc", "9", "clang", "9", "cmake", "3.16.4"]

--- a/docker_images/ci-functional/Dockerfile
+++ b/docker_images/ci-functional/Dockerfile
@@ -33,4 +33,23 @@ RUN apt-get -qq install -y --no-install-recommends \
     clang-9 clang-7 \
     g++-9-multilib g++-7-multilib
 
-#ENTRYPOINT ["/bin/bash"]
+# Alternatives for GCC
+COPY select_gcc.sh /root/select_gcc.sh
+RUN chmod +x /root/select_gcc.sh &&\
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 10 &&\
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 20 &&\
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 10 &&\
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 20
+
+# Alternatives for Clang
+COPY select_clang.sh /root/select_clang.sh
+RUN chmod +x /root/select_clang.sh &&\
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 10 &&\
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 20 &&\
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-9 10 &&\
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-7 20
+
+COPY select_alternatives.sh /root/select_alternatives.sh
+RUN chmod +x /root/select_alternatives.sh
+ENTRYPOINT ["/root/select_alternatives.sh" ]
+CMD ["gcc", "9", "clang", "9"]

--- a/docker_images/ci-functional/select_alternatives.sh
+++ b/docker_images/ci-functional/select_alternatives.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "usage: $0 gcc $1 $2 clang $3 $4" 1>&2
+# echo "usage: $0 gcc $1 $2 clang $3 $4" 1>&2
 
 if [[ $1 != gcc || $3 != clang ]]; then
     echo "usage: $0 gcc <version> clang <version>" 1>&2
@@ -10,4 +10,9 @@ fi
 /root/select_gcc.sh $2
 /root/select_clang.sh $4
 
-/bin/bash
+# Pass the rest of the arguments to /bin/bash
+all_args=("$@")
+rest_args=("${all_args[@]:4}")
+echo "${rest_args[@]}"
+
+/bin/bash "${rest_args[@]}"

--- a/docker_images/ci-functional/select_alternatives.sh
+++ b/docker_images/ci-functional/select_alternatives.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "usage: $0 gcc $1 $2 clang $3 $4" 1>&2
+
+if [[ $1 != gcc || $3 != clang ]]; then
+    echo "usage: $0 gcc <version> clang <version>" 1>&2
+    exit 1
+fi
+
+/root/select_gcc.sh $2
+/root/select_clang.sh $4
+
+/bin/bash

--- a/docker_images/ci-functional/select_alternatives.sh
+++ b/docker_images/ci-functional/select_alternatives.sh
@@ -2,17 +2,18 @@
 
 # echo "usage: $0 gcc $1 $2 clang $3 $4" 1>&2
 
-if [[ $1 != gcc || $3 != clang ]]; then
-    echo "usage: $0 gcc <version> clang <version>" 1>&2
+if [[ $1 != gcc || $3 != clang || $5 != cmake ]]; then
+    echo "usage: $0 gcc <version> clang <version> cmake <version>" 1>&2
     exit 1
 fi
 
 /root/select_gcc.sh $2
 /root/select_clang.sh $4
+/root/select_cmake.sh $6
 
 # Pass the rest of the arguments to /bin/bash
 all_args=("$@")
-rest_args=("${all_args[@]:4}")
-echo "${rest_args[@]}"
+rest_args=("${all_args[@]:6}")
 
+echo "/bin/bash ${rest_args[@]}" 1>&2
 /bin/bash "${rest_args[@]}"

--- a/docker_images/ci-functional/select_clang.sh
+++ b/docker_images/ci-functional/select_clang.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "usage: $0 version" 1>&2
+    exit 1
+fi
+
+if [ ! -f "/usr/bin/clang-$1" ] || [ ! -f "/usr/bin/clang++-$1" ]; then
+    echo "no such version clang/clang++ installed" 1>&2
+    exit 1
+fi
+
+update-alternatives --set clang "/usr/bin/clang-$1"
+update-alternatives --set clang++ "/usr/bin/clang++-$1"

--- a/docker_images/ci-functional/select_clang.sh
+++ b/docker_images/ci-functional/select_clang.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
 if [ -z "$1" ]; then
-    echo "usage: $0 version" 1>&2
+    echo "usage: $0 <version>" 1>&2
     exit 1
 fi
+
+echo "Set Clang version $1"
 
 if [ ! -f "/usr/bin/clang-$1" ] || [ ! -f "/usr/bin/clang++-$1" ]; then
     echo "no such version clang/clang++ installed" 1>&2

--- a/docker_images/ci-functional/select_clang.sh
+++ b/docker_images/ci-functional/select_clang.sh
@@ -5,7 +5,7 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-echo "Set Clang version $1"
+echo "Set Clang version $1" 1>&2
 
 if [ ! -f "/usr/bin/clang-$1" ] || [ ! -f "/usr/bin/clang++-$1" ]; then
     echo "no such version clang/clang++ installed" 1>&2

--- a/docker_images/ci-functional/select_cmake.sh
+++ b/docker_images/ci-functional/select_cmake.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "usage: $0 <version>" 1>&2
+    exit 1
+fi
+
+echo "Set CMake version $1" 1>&2
+update-alternatives --set cmake "/root/conan_packages/.conan/data/cmake/$1/_/_/package/44fcf6b9a7fb86b2586303e3db40189d3b511830/bin/cmake"

--- a/docker_images/ci-functional/select_gcc.sh
+++ b/docker_images/ci-functional/select_gcc.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ -z "$1" ]; then
+    echo "usage: $0 version" 1>&2
+    exit 1
+fi
+
+if [ ! -f "/usr/bin/gcc-$1" ] || [ ! -f "/usr/bin/g++-$1" ]; then
+    echo "no such version gcc/g++ installed" 1>&2
+    exit 1
+fi
+
+update-alternatives --set gcc "/usr/bin/gcc-$1"
+update-alternatives --set g++ "/usr/bin/g++-$1"

--- a/docker_images/ci-functional/select_gcc.sh
+++ b/docker_images/ci-functional/select_gcc.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
 if [ -z "$1" ]; then
-    echo "usage: $0 version" 1>&2
+    echo "usage: $0 <version>" 1>&2
     exit 1
 fi
+
+echo "Set GCC version $1"
 
 if [ ! -f "/usr/bin/gcc-$1" ] || [ ! -f "/usr/bin/g++-$1" ]; then
     echo "no such version gcc/g++ installed" 1>&2

--- a/docker_images/ci-functional/select_gcc.sh
+++ b/docker_images/ci-functional/select_gcc.sh
@@ -5,7 +5,7 @@ if [ -z "$1" ]; then
     exit 1
 fi
 
-echo "Set GCC version $1"
+echo "Set GCC version $1" 1>&2
 
 if [ ! -f "/usr/bin/gcc-$1" ] || [ ! -f "/usr/bin/g++-$1" ]; then
     echo "no such version gcc/g++ installed" 1>&2

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -4,7 +4,12 @@ LABEL maintainer="Conan.io <info@conan.io>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-COPY environment.sh /root/environment.sh
+#COPY environment.sh /root/environment.sh
+
+ENV PY27 /root/.pyenv/versions/2.7.17/bin/python
+ENV PY36 /root/.pyenv/versions/3.6.10/bin/python
+ENV PY37 /root/.pyenv/versions/3.7.6/bin/python
+ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -14,11 +14,10 @@ ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
        sudo ca-certificates \
-       make build-essential \
-       zlib1g-dev \
-       wget \
-       curl \
-       git \
+       # pyenv requires
+       make build-essential libssl-dev zlib1g-dev libbz2-dev \
+       libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
+       xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
     \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> ~/.bashrc \

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -29,4 +29,4 @@ RUN apt-get -qq update \
 
 RUN apt-get -qq remove make build-essential git gcc
 
-#ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer="Conan.io <info@conan.io>"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-#COPY environment.sh /root/environment.sh
-
 ENV PY27 /root/.pyenv/versions/2.7.17/bin/python
 ENV PY35 /root/.pyenv/versions/3.5.9/bin/python
 ENV PY37 /root/.pyenv/versions/3.7.6/bin/python

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 #COPY environment.sh /root/environment.sh
 
 ENV PY27 /root/.pyenv/versions/2.7.17/bin/python
-ENV PY36 /root/.pyenv/versions/3.6.10/bin/python
+ENV PY35 /root/.pyenv/versions/3.5.9/bin/python
 ENV PY37 /root/.pyenv/versions/3.7.6/bin/python
 ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -37,9 +37,6 @@ RUN apt-get -qq update \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
     && . ~/.bashrc \
     && pyenv update \
-    && pyenv install 3.8.1 \
-    && pyenv install 3.7.6 \
-    && pyenv install 3.6.10 \
-    && pyenv install 2.7.17
+    && pyenv install 3.8.1
 
-ENTRYPOINT /bin/bash && source /root/environment.sh
+#ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:eoan
+
+LABEL maintainer="Conan.io <info@conan.io>"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY environment.sh /root/environment.sh
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+       sudo ca-certificates \
+       make \
+       build-essential \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       curl \
+       llvm \
+       libncurses5-dev \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libffi-dev \
+       liblzma-dev \
+       python-openssl \
+       git \
+       python3 \
+    \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1\
+    \
+    && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
+    && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
+    && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
+    && . ~/.bashrc \
+    && pyenv update \
+    && pyenv install 3.8.1 \
+    && pyenv install 3.7.6 \
+    && pyenv install 3.6.10 \
+    && pyenv install 2.7.17
+
+ENTRYPOINT /bin/bash && source /root/environment.sh

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -14,27 +14,10 @@ ENV PY38 /root/.pyenv/versions/3.8.1/bin/python
 RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
        sudo ca-certificates \
-       make \
-       build-essential \
-       libssl-dev \
-       zlib1g-dev \
-       libbz2-dev \
-       libreadline-dev \
-       libsqlite3-dev \
+       make build-essential \
        wget \
        curl \
-       llvm \
-       libncurses5-dev \
-       libncursesw5-dev \
-       xz-utils \
-       tk-dev \
-       libffi-dev \
-       liblzma-dev \
-       python-openssl \
        git \
-       python3 \
-    \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1\
     \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
     && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> ~/.bashrc \
@@ -46,5 +29,7 @@ RUN apt-get -qq update \
     && pyenv install 3.7.6 \
     && pyenv install 3.5.9 \
     && pyenv install 2.7.17
+
+RUN apt-get -qq remove make build-essential git
 
 #ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -42,6 +42,9 @@ RUN apt-get -qq update \
     && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
     && . ~/.bashrc \
     && pyenv update \
-    && pyenv install 3.8.1
+    && pyenv install 3.8.1 \
+    && pyenv install 3.7.6 \
+    && pyenv install 3.5.9 \
+    && pyenv install 2.7.17
 
 #ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get -qq update \
     && apt-get -qq install -y --no-install-recommends \
        sudo ca-certificates \
        make build-essential \
+       zlib1g-dev \
        wget \
        curl \
        git \

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -20,10 +20,9 @@ RUN apt-get -qq update \
        xz-utils tk-dev libffi-dev liblzma-dev python-openssl git \
     \
     && curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash \
-    && echo 'export PATH="/root/.pyenv/bin:$PATH"' >> ~/.bashrc \
-    && echo 'eval "$(pyenv init -)"' >> ~/.bashrc \
-    && echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc \
-    && . ~/.bashrc \
+    && export PATH="/root/.pyenv/bin:$PATH" \
+    && pyenv init - \
+    && pyenv virtualenv-init - \
     && pyenv update \
     && pyenv install 3.8.1 \
     && pyenv install 3.7.6 \

--- a/docker_images/ci-unittests/Dockerfile
+++ b/docker_images/ci-unittests/Dockerfile
@@ -30,6 +30,6 @@ RUN apt-get -qq update \
     && pyenv install 3.5.9 \
     && pyenv install 2.7.17
 
-RUN apt-get -qq remove make build-essential git
+RUN apt-get -qq remove make build-essential git gcc
 
 #ENTRYPOINT ["/bin/bash"]

--- a/docker_images/ci-unittests/environment.sh
+++ b/docker_images/ci-unittests/environment.sh
@@ -1,0 +1,4 @@
+export PY27="/root/.pyenv/versions/2.7.17/bin/python"
+export PY36="/root/.pyenv/versions/3.6.10/bin/python"
+export PY37="/root/.pyenv/versions/3.7.6/bin/python"
+export PY38="/root/.pyenv/versions/3.8.1/bin/python"

--- a/docker_images/ci-unittests/environment.sh
+++ b/docker_images/ci-unittests/environment.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 export PY27="/root/.pyenv/versions/2.7.17/bin/python"
 export PY36="/root/.pyenv/versions/3.6.10/bin/python"
 export PY37="/root/.pyenv/versions/3.7.6/bin/python"

--- a/docker_images/ci-unittests/environment.sh
+++ b/docker_images/ci-unittests/environment.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-export PY27="/root/.pyenv/versions/2.7.17/bin/python"
-export PY35="/root/.pyenv/versions/3.5.9/bin/python"
-export PY37="/root/.pyenv/versions/3.7.6/bin/python"
-export PY38="/root/.pyenv/versions/3.8.1/bin/python"

--- a/docker_images/ci-unittests/environment.sh
+++ b/docker_images/ci-unittests/environment.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 export PY27="/root/.pyenv/versions/2.7.17/bin/python"
-export PY36="/root/.pyenv/versions/3.6.10/bin/python"
+export PY35="/root/.pyenv/versions/3.5.9/bin/python"
 export PY37="/root/.pyenv/versions/3.7.6/bin/python"
 export PY38="/root/.pyenv/versions/3.8.1/bin/python"

--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -56,8 +56,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
         traverse_namespace = "--traverse-namespace"
 
     #  --nocapture
-    command = "pip install \"virtualenv<20.0.0\" && " \
-              "virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
+    command = "virtualenv --python \"{pyenv}\" \"{venv_dest}\" && " \
               "{source_cmd} \"{venv_exe}\" && " \
               "{pip_installs} " \
               "python setup.py install && " \

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -15,6 +15,10 @@ class TestRunner {
 
 
     void run(){
+        script.stage("This is staging") {
+            script.echo "Yes, it is"
+        }
+
         cancelPreviousCommits()
         testLevelConfig.init() // This will read the tags from the PR if this is a PR
         runRESTTests()


### PR DESCRIPTION

ci-unittests
-----------

This image contains only Python, **no system tools are available (there is no git, cmake or compiler)**.
It provides several python versions that can be referenced using environment variables like PY27,
PY35, PY37,...

ci-functional
-------------

This image contains the same Python versions as `ci-unittests`, but it also contains **system tools**
like Git, CMake, GCC or Clang. The installed versions are available using environment variables and
they can also be installed like the preferred alternative when starting the container:

```
docker run -it travis-ci-ci-functional:latest gcc 7 clang 9 cmake 3.16.4
```
