### PR TITLE
Fix LNK1318 random failures in windows nodes

### DIFF
--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,7 @@ class TestRunner {
                     if (slaveLabel == "Windows") {
                         try {
 
-                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
+                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${script.env.BUILD_TAG}"]) {
                                 script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,8 @@ class TestRunner {
                     if (slaveLabel == "Windows") {
                         try {
 
-                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}"]) {
+                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}, _MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
+                                script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }
                         }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,7 @@ class TestRunner {
                     if (slaveLabel == "Windows") {
                         try {
 
-                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}, _MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
+                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", _"MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
                                 script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -189,9 +189,7 @@ class TestRunner {
 
                     if (slaveLabel == "Windows") {
                         try {
-
                             script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${script.env.BUILD_TAG}-${pyver}"]) {
-                                script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }
                         }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,7 @@ class TestRunner {
                     if (slaveLabel == "Windows") {
                         try {
 
-                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", _"MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
+                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${BUILD_TAG}"]) {
                                 script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -190,7 +190,7 @@ class TestRunner {
                     if (slaveLabel == "Windows") {
                         try {
 
-                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${script.env.BUILD_TAG}"]) {
+                            script.withEnv(["CONAN_TEST_FOLDER=${workdir}", "_MSPDBSRV_ENDPOINT_=${script.env.BUILD_TAG}-${pyver}"]) {
                                 script.bat(script: "set")
                                 script.bat(script: "python python_runner/runner.py ${testModule} ${pyver} ${sourcedir} \"${workdir}\" ${numcores} ${flavor_cmd} ${eTags}")
                             }


### PR DESCRIPTION
We have been getting random `LNK1318` failures in the Windows nodes for Conan Jenkins ci. Looks like a [known issue](https://github.com/rust-lang/rust/issues/33145#issuecomment-214561730
) and seems like setting the undocumented `_MSPDBSRV_ENDPOINT_` variable to [an unique value for each parallel build could fix this](https://issues.jenkins.io/browse/JENKINS-9104?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel).

