### PR TITLE
Launch "rest_api" and "local_bottle" marked tests with others

### DIFF
--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -24,14 +24,15 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
                             "activate")
 
     tags_str = []
-    if excluded_tags:
+    if excluded_tags or include_tags:
         for tag in excluded_tags:
             tags_str.append("not {}".format(tag))
         tags_str = '-m "%s"' % " and ".join(tags_str)
-    if include_tags:
         for tag in include_tags:
             tags_str.append("{}".format(tag))
         tags_str = '-m "%s"' % " or ".join(tags_str)
+    else:
+        tags_str = ""
 
     pyenv = pylocations[pyver]
     source_cmd = "." if platform.system() != "Windows" else ""

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -19,13 +19,12 @@ class TestRunner {
         cancelPreviousCommits()
         testLevelConfig.init() // This will read the tags from the PR if this is a PR
         script.echo("Branch: ${script.env.BRANCH_NAME}")
-        runRegularBuildTests()
-        // if(script.env.JOB_NAME == "ConanNightly" || script.env.BRANCH_NAME =~ /(^release.*)|(^master)/) {
-        //     runReleaseTests()
-        // }
-        // else{
-        //     runRegularBuildTests()
-        // }
+        if(script.env.JOB_NAME == "ConanNightly" || script.env.BRANCH_NAME =~ /(^release.*)|(^master)/) {
+            runReleaseTests()
+        }
+        else{
+            runRegularBuildTests()
+        }
     }
 
     void cancelPreviousCommits(){

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -36,7 +36,10 @@ class TestRunner {
 
 
     private static String getStageLabel(String slaveLabel, boolean enabledRevisions, String pyver, List<String> excludedTags){
-        String eTags = "-e " + excludedTags.join(' -e ')
+        String eTags = ""
+        if(excludedTags){
+            eTags = "-e " + excludedTags.join(' -e ')
+        }
         String ret = "${slaveLabel} - ${getFlavor(enabledRevisions)} - ${pyver} - '${eTags}'"
         return ret
     }

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -18,14 +18,14 @@ class TestRunner {
     void run(){
         cancelPreviousCommits()
         testLevelConfig.init() // This will read the tags from the PR if this is a PR
-        runRESTTests()
         script.echo("Branch: ${script.env.BRANCH_NAME}")
-        if(script.env.JOB_NAME == "ConanNightly" || script.env.BRANCH_NAME =~ /(^release.*)|(^master)/) {
-            runReleaseTests()
-        }
-        else{
-            runRegularBuildTests()
-        }
+        runRegularBuildTests()
+        // if(script.env.JOB_NAME == "ConanNightly" || script.env.BRANCH_NAME =~ /(^release.*)|(^master)/) {
+        //     runReleaseTests()
+        // }
+        // else{
+        //     runRegularBuildTests()
+        // }
     }
 
     void cancelPreviousCommits(){

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -39,7 +39,7 @@ class TestRunner {
         if(excludedTags){
             eTags = "-e " + excludedTags.join(' -e ')
         }
-        String ret = "${slaveLabel} - ${getFlavor(enabledRevisions)} - ${pyver} - '${eTags}'"
+        String ret = "${slaveLabel} - ${getFlavor(enabledRevisions)} - ${pyver} '${eTags}'"
         return ret
     }
 

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -96,8 +96,6 @@ class TestRunner {
 
     void runReleaseTests(){
         List<String> excludedTags = testLevelConfig.getEffectiveExcludedTags()
-        excludedTags.add("rest_api")
-        excludedTags.add("local_bottle")
         for(revisionsEnabled in [true, false]) {
             Map<String, Closure> builders = [:]
             for (slaveLabel in ["Linux", "Macos", "Windows"]) {

--- a/src/org/jfrog/conanci/TestRunner.groovy
+++ b/src/org/jfrog/conanci/TestRunner.groovy
@@ -50,26 +50,8 @@ class TestRunner {
         return revisionsEnabled ? " --flavor enabled_revisions" : ""
     }
 
-    void runRESTTests(){
-        List<String> excludedTags = []
-        List<String> includedTags = ["rest_api", "local_bottle"]
-        def slaveLabels = ["Windows", "Linux"]
-        Map<String, Closure> parallelRestBuilders = [:]
-        for (def slaveLabel in slaveLabels) {
-            List<String> pyVers = testLevelConfig.getEffectivePyvers(slaveLabel)
-            for (def pyver in pyVers) {
-                String stageLabel = "${slaveLabel} Https server tests - ${pyver}"
-                parallelRestBuilders[stageLabel] = getTestClosure(slaveLabel, stageLabel, false, pyver, excludedTags, includedTags)
-            }
-        }
-        script.parallel(parallelRestBuilders)
-    }
-
-
     void runRegularBuildTests(){
         List<String> excludedTags = testLevelConfig.getEffectiveExcludedTags()
-        excludedTags.add("rest_api")
-        excludedTags.add("local_bottle")
         for(revisionsEnabled in testLevelConfig.getEffectiveRevisionsConfigurations()) {
             // First (revisions or not) for linux
             Map<String, Closure> builders = [:]


### PR DESCRIPTION
The intention is launching all tests at once without separating "rest_api" and "local_bottle" marked tests.
The reason these tests were launched separately is because we had some ports overlaps in CI and they frequently failed, but now that problem is solved so can be launched along the rest of tests.