### PR TITLE
Summary at the end of the tests

### DIFF
--- a/resources/org/jfrog/conanci/python_runner/runner.py
+++ b/resources/org/jfrog/conanci/python_runner/runner.py
@@ -54,7 +54,7 @@ def run_tests(module_path, pyver, source_folder, tmp_folder, flavor, excluded_ta
               "{pip_installs} " \
               "python setup.py install && " \
               "conan --version && conan --help && " \
-              "pytest {module_path} {tags_str} " \
+              "pytest -rf {module_path} {tags_str} " \
               "{multiprocess} ".format(**{"module_path": module_path,
                                           "pyenv": pyenv,
                                           "tags_str": tags_str,


### PR DESCRIPTION
To show this summary at the end with the failed together. The output traces are also showed before (no changes).

```
======================================================================================== short test summary info =========================================================================================
FAILED conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py::test_build_modules_from_build_context - Exception: 
FAILED conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py::test_build_modules_and_target_from_build_context - Exception: 
FAILED conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py::test_build_modules_from_host_and_target_from_build_context - Exception: 
FAILED conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_protobuf.py::test_build_modules_and_target_from_host_context - Exception: 
================================================================================ 4 failed, 1 passed, 1 warning in 10.44s =================================================================================

```