### PR TITLE
Bring ci-docs image requirements.txt in-sync with upstream's

### DIFF
--- a/docker_images/ci-docs/requirements.txt
+++ b/docker_images/ci-docs/requirements.txt
@@ -1,8 +1,8 @@
-sphinx==1.7.9
-docutils<0.18
-sphinx-sitemap>=2.1.0
-sphinxcontrib-spelling
-sphinx-notfound-page
-jinja2<=3.0.3
-watchdog[watchmedo]==2.2.0
-colorama>=0.4.3, <0.5.0
+sphinx==7.2.6
+sphinx-sitemap==2.5.1
+sphinxcontrib-spelling==8.0.0
+sphinx-notfound-page==1.0.0
+sphinxcontrib-jquery==4.1
+sphinxcontrib-youtube==1.4.1
+docutils==0.20.1
+jinja2==3.1.3

--- a/docker_images/ci-docs/requirements.txt
+++ b/docker_images/ci-docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx-notfound-page==1.0.0
 sphinxcontrib-jquery==4.1
 sphinxcontrib-youtube==1.4.1
 docutils==0.20.1
-jinja2==3.1.3
+jinja2==3.1.4


### PR DESCRIPTION
This uses the same packages and versions than the main docs repo, as we were having some issues when trying to build the new conan 2 releases which used what seems like incompatible versions.

The install here is done to save some time not needed to redownload common dependencies for each branch